### PR TITLE
fix: update mamba script URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 
 SYSTEM_NAME := $(shell uname)
 SYSTEM_ARCHITECTURE := $(shell uname -m)
-MAMBA_INSTALL_SCRIPT := Miniforge-pypy3-$(SYSTEM_NAME)-$(SYSTEM_ARCHITECTURE).sh
+MAMBA_INSTALL_SCRIPT := Miniforge3-$(SYSTEM_NAME)-$(SYSTEM_ARCHITECTURE).sh
 
 MAMBA_ENV_NAME := handdgp
 PACKAGE_FOLDER := src/handdgp


### PR DESCRIPTION
**Issue**: running `make install-mamba` does not work, and resulted in this error on my 2022 MacBook Pro:
```bash
./Miniforge-pypy3-Darwin-arm64.sh: line 1: Not: command not found
```

**Root cause**: The download URL's for miniforge changed in [24.11.2-0](https://github.com/conda-forge/miniforge/releases/tag/24.11.2-0), and executables start with `Miniforge3-*` now.

**Fix**: Change executable paths to be `Miniforge3-*` instead of `Miniforge-pypy3-*` and `make install-mamba` downloads/runs the correct script.